### PR TITLE
Release/ver.2.1

### DIFF
--- a/pixiv_downloader.py
+++ b/pixiv_downloader.py
@@ -52,9 +52,7 @@ main_saving_direcory_path = "./img/"
 ugoira_gif  = True
 #画質良、ファイルサイズ小、ループしない（再生ソフト次第）、保存場所は直下
 ugoira_mp4  = True
-#画質最高（劣化なし）、ファイルサイズ小、ループ、ファイル移動できない（元の画像を参照しているため）、保存場所はugoiraフォルダ内
-ugoira_html = True
-#画質最高（劣化なし）、ループ、ファイルサイズ大、移動可、保存場所はugoiraフォルダ内
+#画質最高（劣化なし）、ループ、ファイルサイズ大、移動可、保存場所はugoiraフォルダ内、delayが正確
 html_onefile = True
 
 #Filter by tag　e.g. target_tag = ["Fate/GrandOrder","FGO","FateGO","Fate/staynight"]
@@ -292,48 +290,7 @@ for user_id in client_info["ids"]:
                             #print('written')
                             
                             
-                        #ローカルを参照するhtml
-                        #https://qiita.com/choshicure/items/8795bf929e34af6622fc
-                        if ugoira_html == True:
 
-                            paths_json = json.dumps(frames)
-
-                            html = """
-                            <!DOCTYPE html>
-                            <html lang="en">
-                            <head>
-                                <meta charset="UTF-8">
-                                <meta name="viewport" content="width=device-width, initial-scale=1.0">
-                                <title>Document</title>
-                            </head>
-                            <body>
-                                <canvas id="ugoira" width="{width}" height="{height}"></canvas>
-                                <script>
-
-                                    const paths = {paths_json};
-                                    const images = paths.map(path => {{
-                                        const image = new Image();
-                                        image.src = path;
-                                        return image;
-                                        }});
-
-                                    const canvas = document.querySelector('#ugoira');
-                                    const context = canvas.getContext('2d');
-                                    let count = 0;
-                                    window.addEventListener('load', function(){{
-                                        setInterval(function(){{
-                                            context.clearRect(0, 0, canvas.width, canvas.height);
-                                            context.drawImage(images[count], 0, 0);
-                                            count++;
-                                            if(count>={frames}) count=0;
-                                        }}, {delay});
-                                    }});
-                                </script>
-                            </body>
-                            </html>
-                            """.format(width=width, height=height, frames=ugoira_frames, illust_id=illust_id, delay=ugoira_delay, paths_json=paths_json)
-                            with open(f'{dir_name}/ugoira.html', 'w', encoding='utf-8') as f:
-                                f.write(html)
                                 
                                 
                         #一つのファイルにまとめたhtml

--- a/pixiv_downloader.py
+++ b/pixiv_downloader.py
@@ -341,9 +341,10 @@ for user_id in client_info["ids"]:
                             import base64
                             illust_b64 = []
                             img_ext = frames[0].split('.')[-1]
-                            for frame in frames:
+                            for num, frame in enumerate(frames):
                                 with open(frame, 'rb') as f:
-                                    illust_b64.append(f'data:image/{img_ext};base64,{base64.b64encode(f.read()).decode()}')
+                                    illust_b64.append([f'data:image/{img_ext};base64,{base64.b64encode(f.read()).decode()}', ugoira.ugoira_metadata.frames[num]['delay']])
+
                             html = """
                             <!DOCTYPE html>
                             <html lang="en">
@@ -359,24 +360,23 @@ for user_id in client_info["ids"]:
                                     const images = [];
                                     for(let i=0; i<{frames}; i++){{
                                         const img = new Image();
-                                        img.src = illust_b64[i];
-                                        images.push(img);
+                                        img.src = illust_b64[i][0];
+                                        images.push([img, illust_b64[i][1]]);
                                     }}
                                     const canvas = document.querySelector('#ugoira');
                                     const context = canvas.getContext('2d');
                                     let count = 0;
-                                    window.addEventListener('load', function(){{
-                                        setInterval(function(){{
-                                            context.clearRect(0, 0, canvas.width, canvas.height);
-                                            context.drawImage(images[count], 0, 0);
-                                            count++;
-                                            if(count>={frames}) count=0;
-                                        }}, {delay});
-                                    }});
+                                    const drawImage = (index) => {{
+                                        if(index>={frames}) index=0;
+                                        context.clearRect(0, 0, canvas.width, canvas.height);
+                                        context.drawImage(images[index][0], 0, 0);
+                                        setTimeout(drawImage, images[index][1], index+1)
+                                    }};
+                                    window.addEventListener('load', () => drawImage(0));
                                 </script>
                             </body>
                             </html>
-                            """.format(width=width, height=height, frames=ugoira_frames, illust_id=illust_id, delay=ugoira_delay, illust_b64=str(illust_b64))
+                            """.format(width=width, height=height, frames=ugoira_frames, illust_id=illust_id, illust_b64=str(illust_b64))
                             with open(f'{dir_name}/ugoira_onefile.html', 'w', encoding='utf-8') as f:
                                 f.write(html)
 
@@ -419,7 +419,6 @@ for user_id in client_info["ids"]:
         print("-----------------------------")
         print("Download complete!　Thanks to {:<10}".format(user_id) + user_name)
         print()
-
 
 
 

--- a/pixiv_downloader_tqdm.py
+++ b/pixiv_downloader_tqdm.py
@@ -54,9 +54,7 @@ main_saving_direcory_path = "./img/"
 ugoira_gif  = True
 #画質良、ファイルサイズ小、ループしない（再生ソフト次第）、保存場所は直下
 ugoira_mp4  = True
-#画質最高（劣化なし）、ファイルサイズ小、ループ、ファイル移動できない（元の画像を参照しているため）、保存場所はugoiraフォルダ内
-ugoira_html = True
-#画質最高（劣化なし）、ループ、ファイルサイズ大、移動可、保存場所はugoiraフォルダ内
+#画質最高（劣化なし）、ループ、ファイルサイズ大、移動可、保存場所はugoiraフォルダ内、delayが正確
 html_onefile = True
 
 #Filter by tag　e.g. target_tag = ["Fate/GrandOrder","FGO","FateGO","Fate/staynight"]
@@ -308,48 +306,7 @@ for user_id in tqdm(client_info["ids"], desc='users', leave=False):
                             #print('written')
                             
                             
-                        #ローカルを参照するhtml
-                        #https://qiita.com/choshicure/items/8795bf929e34af6622fc
-                        if ugoira_html == True:
 
-                            paths_json = json.dumps(frames)
-
-                            html = """
-                            <!DOCTYPE html>
-                            <html lang="en">
-                            <head>
-                                <meta charset="UTF-8">
-                                <meta name="viewport" content="width=device-width, initial-scale=1.0">
-                                <title>Document</title>
-                            </head>
-                            <body>
-                                <canvas id="ugoira" width="{width}" height="{height}"></canvas>
-                                <script>
-
-                                    const paths = {paths_json};
-                                    const images = paths.map(path => {{
-                                        const image = new Image();
-                                        image.src = path;
-                                        return image;
-                                        }});
-
-                                    const canvas = document.querySelector('#ugoira');
-                                    const context = canvas.getContext('2d');
-                                    let count = 0;
-                                    window.addEventListener('load', function(){{
-                                        setInterval(function(){{
-                                            context.clearRect(0, 0, canvas.width, canvas.height);
-                                            context.drawImage(images[count], 0, 0);
-                                            count++;
-                                            if(count>={frames}) count=0;
-                                        }}, {delay});
-                                    }});
-                                </script>
-                            </body>
-                            </html>
-                            """.format(width=width, height=height, frames=ugoira_frames, illust_id=illust_id, delay=ugoira_delay, paths_json=paths_json)
-                            with open(f'{dir_name}/ugoira.html', 'w', encoding='utf-8') as f:
-                                f.write(html)
                                 
                                 
                         #一つのファイルにまとめたhtml

--- a/pixiv_downloader_tqdm.py
+++ b/pixiv_downloader_tqdm.py
@@ -356,9 +356,10 @@ for user_id in tqdm(client_info["ids"], desc='users', leave=False):
                             import base64
                             illust_b64 = []
                             img_ext = frames[0].split('.')[-1]
-                            for frame in frames:
+                            for num, frame in enumerate(frames):
                                 with open(frame, 'rb') as f:
-                                    illust_b64.append(f'data:image/{img_ext};base64,{base64.b64encode(f.read()).decode()}')
+                                    illust_b64.append([f'data:image/{img_ext};base64,{base64.b64encode(f.read()).decode()}', ugoira.ugoira_metadata.frames[num]['delay']])
+
                             html = """
                             <!DOCTYPE html>
                             <html lang="en">
@@ -374,24 +375,23 @@ for user_id in tqdm(client_info["ids"], desc='users', leave=False):
                                     const images = [];
                                     for(let i=0; i<{frames}; i++){{
                                         const img = new Image();
-                                        img.src = illust_b64[i];
-                                        images.push(img);
+                                        img.src = illust_b64[i][0];
+                                        images.push([img, illust_b64[i][1]]);
                                     }}
                                     const canvas = document.querySelector('#ugoira');
                                     const context = canvas.getContext('2d');
                                     let count = 0;
-                                    window.addEventListener('load', function(){{
-                                        setInterval(function(){{
-                                            context.clearRect(0, 0, canvas.width, canvas.height);
-                                            context.drawImage(images[count], 0, 0);
-                                            count++;
-                                            if(count>={frames}) count=0;
-                                        }}, {delay});
-                                    }});
+                                    const drawImage = (index) => {{
+                                        if(index>={frames}) index=0;
+                                        context.clearRect(0, 0, canvas.width, canvas.height);
+                                        context.drawImage(images[index][0], 0, 0);
+                                        setTimeout(drawImage, images[index][1], index+1)
+                                    }};
+                                    window.addEventListener('load', () => drawImage(0));
                                 </script>
                             </body>
                             </html>
-                            """.format(width=width, height=height, frames=ugoira_frames, illust_id=illust_id, delay=ugoira_delay, illust_b64=str(illust_b64))
+                            """.format(width=width, height=height, frames=ugoira_frames, illust_id=illust_id, illust_b64=str(illust_b64))
                             with open(f'{dir_name}/ugoira_onefile.html', 'w', encoding='utf-8') as f:
                                 f.write(html)
 

--- a/pixiv_downloader_tqdm.py
+++ b/pixiv_downloader_tqdm.py
@@ -115,7 +115,8 @@ for user_id in tqdm(client_info["ids"], desc='users', leave=False):
             local_user_name = os.path.basename(local_dir).rsplit("(", 1)[0]
             if local_user_id == str(user_id):
                 if user_name != local_user_name:
-                    print(local_dir + " を次に変更 " + saving_direcory_path)
+                    #print(local_dir + " を次に変更 " + saving_direcory_path)
+                    tqdm.write(local_dir + " を次に変更 " + saving_direcory_path)
                     os.rename(local_dir, saving_direcory_path)
                     sleep(3)
                 break


### PR DESCRIPTION
version2.1では以下の変更があります。

ローカルを参照するhtml、ugoira_htmlを削除 
参照する画像パスが絶対パスになってしまっているので、ローカルを参照するhtmlを削除した。

残っていたprintをtqdm.writeに変更

うごイラのdelayの変化を実装 
https://qiita.com/choshicure/items/8795bf929e34af6622fc#%E8%BF%BD%E8%A8%9820220115
今まではdelayは一定だったが、htmlファイルにて可変とした。
