### PR TITLE
漫画作品をダウンロードできるように+細かな修正

### DIFF
--- a/pixiv_downloader.py
+++ b/pixiv_downloader.py
@@ -21,6 +21,26 @@ import numpy as np
 import re
 
 
+#https://qiita.com/yuki_2020/items/cdab3b0ce451bc9e3179
+def rename_for_windows(name):
+    while True:
+        tmp = name
+        #半角文字の削除        
+        name = name.translate((str.maketrans({'\a':'','\b':'','\f':'','\n':'','\r':'','\t':'','\v':'',"\'":"'",'\"':'"','\0':''})))    
+        #エスケープシーケンスを削除
+        name = name.translate((str.maketrans({'\\':'￥','/': '／' , ':': '：', '*': '＊', '?': '？', '"': "”", '>': '＞', '<': '＜', '|': '｜'})))
+        #先頭/末尾のドットの削除 
+        name = name.strip(".")
+        #先頭/末尾の半角スペースを削除
+        name = name.strip(" ")
+        #先頭/末尾の全角スペースを削除
+        name = name.strip("　")
+
+        if name == tmp:
+            break
+
+    return name
+
 #client.jsonの読み込み処理
 f = open("client.json", "r")
 client_info = json.load(f)
@@ -86,19 +106,7 @@ for user_id in client_info["ids"]:
 
         #フォルダパス作成
         directory_user_name = user_name
-        #エスケープシーケンスを削除
-        #https://pg-chain.com/python-escape
-        directory_user_name = directory_user_name.translate((str.maketrans({'\n': '','\0': '','\t': '','\r': '',"\'": "'",'\"': '"', '\\':''})))
-        #windowsで使えるフォルダ名に変更
-        #https://www.itc.u-toyama.ac.jp/el/win7/restricted.html
-        directory_user_name = directory_user_name.translate((str.maketrans({'/': '／' , ':': '：', '*': '＊', '?': '？', '"': "”", '>': '＞', '<': '＜', '|': '｜'})))
-        #https://all.undo.jp/asr/1st/document/01_03.html
-        #先頭ドット、末尾ドット
-        directory_user_name = directory_user_name.strip(".")
-        #半角スペース
-        directory_user_name = directory_user_name.strip(" ")
-        #全角スペース
-        directory_user_name = directory_user_name.strip("　")
+        directory_user_name = rename_for_windows(directory_user_name)
         saving_direcory_path = main_saving_direcory_path + directory_user_name + ("(") +str(user_id) + (")") + "/"
 
         #フォルダ名アップデート

--- a/pixiv_downloader.py
+++ b/pixiv_downloader.py
@@ -360,11 +360,9 @@ for user_id in client_info["ids"]:
                 if finish_flag == True:
                    break
                
-                sleep(1)
                 next_qs = aapi.parse_qs(user_illusts.next_url)
                 if next_qs == None:
-                    break
-                    
+                    break                    
                 else:
                     sleep(1)
                     user_illusts = aapi.user_illusts(**next_qs)

--- a/pixiv_downloader.py
+++ b/pixiv_downloader.py
@@ -78,7 +78,7 @@ html_onefile = True
 #Filter by tag　e.g. target_tag = ["Fate/GrandOrder","FGO","FateGO","Fate/staynight"]
 select_tags = [] #同じtag内に複数書くと少なくとも一つあればダウンロード
 select_tags2 = []#異なるタグ間のタグはすべて含まれていないとダウンロードされない
-exclude_tags = ["R-18"]#一つでもかぶっていればダウンロードしない
+exclude_tags = ["R-18","R-18G"]#一つでもかぶっていればダウンロードしない
 
 
 #ここから各イラストレーターさんごとの処理

--- a/pixiv_downloader.py
+++ b/pixiv_downloader.py
@@ -142,7 +142,7 @@ for user_id in client_info["ids"]:
         #for i in range(total_works//30)
         
         #こことってこれないとぐるぐる回る
-        user_illusts = aapi.user_illusts(user_id)
+        user_illusts = aapi.user_illusts(user_id, type="")
         while True:
             try:
 
@@ -200,7 +200,7 @@ for user_id in client_info["ids"]:
 
 
 
-                    if illust.type == "illust":
+                    if illust.type == "illust" or illust.type == "manga":
                         if illust.page_count == 1:
                             aapi.download(illust.meta_single_page.original_image_url, saving_direcory_path)
                         else:

--- a/pixiv_downloader_tqdm.py
+++ b/pixiv_downloader_tqdm.py
@@ -82,7 +82,7 @@ html_onefile = True
 #Filter by tag　e.g. target_tag = ["Fate/GrandOrder","FGO","FateGO","Fate/staynight"]
 select_tags = [] #同じtag内に複数書くと少なくとも一つあればダウンロード
 select_tags2 = []#異なるタグ間のタグはすべて含まれていないとダウンロードされない
-exclude_tags = ["R-18"]#一つでもかぶっていればダウンロードしない
+exclude_tags = ["R-18","R-18G"]#一つでもかぶっていればダウンロードしない
 
 
 #ここから各イラストレーターさんごとの処理

--- a/pixiv_downloader_tqdm.py
+++ b/pixiv_downloader_tqdm.py
@@ -378,11 +378,9 @@ for user_id in tqdm(client_info["ids"], desc='users', leave=False):
                 if finish_flag == True:
                    break
                
-                sleep(1)
                 next_qs = aapi.parse_qs(user_illusts.next_url)
                 if next_qs == None:
-                    break
-                    
+                    break                    
                 else:
                     sleep(1)
                     user_illusts = aapi.user_illusts(**next_qs)

--- a/pixiv_downloader_tqdm.py
+++ b/pixiv_downloader_tqdm.py
@@ -23,6 +23,28 @@ from tqdm import tqdm
 #https://www.kimoton.com/entry/20190830/1567128952
 import re
 
+
+#https://qiita.com/yuki_2020/items/cdab3b0ce451bc9e3179
+def rename_for_windows(name):
+    while True:
+        tmp = name
+        #半角文字の削除        
+        name = name.translate((str.maketrans({'\a':'','\b':'','\f':'','\n':'','\r':'','\t':'','\v':'',"\'":"'",'\"':'"','\0':''})))    
+        #エスケープシーケンスを削除
+        name = name.translate((str.maketrans({'\\':'￥','/': '／' , ':': '：', '*': '＊', '?': '？', '"': "”", '>': '＞', '<': '＜', '|': '｜'})))
+        #先頭/末尾のドットの削除 
+        name = name.strip(".")
+        #先頭/末尾の半角スペースを削除
+        name = name.strip(" ")
+        #先頭/末尾の全角スペースを削除
+        name = name.strip("　")
+
+        if name == tmp:
+            break
+
+    return name
+
+
 #client.jsonの読み込み処理
 f = open("client.json", "r")
 client_info = json.load(f)
@@ -91,19 +113,7 @@ for user_id in tqdm(client_info["ids"], desc='users', leave=False):
 
         #フォルダパス作成
         directory_user_name = user_name
-        #エスケープシーケンスを削除
-        #https://pg-chain.com/python-escape
-        directory_user_name = directory_user_name.translate((str.maketrans({'\n': '','\0': '','\t': '','\r': '',"\'": "'",'\"': '"', '\\':''})))
-        #windowsで使えるフォルダ名に変更
-        #https://www.itc.u-toyama.ac.jp/el/win7/restricted.html
-        directory_user_name = directory_user_name.translate((str.maketrans({'/': '／' , ':': '：', '*': '＊', '?': '？', '"': "”", '>': '＞', '<': '＜', '|': '｜'})))
-        #https://all.undo.jp/asr/1st/document/01_03.html
-        #先頭ドット、末尾ドット
-        directory_user_name = directory_user_name.strip(".")
-        #半角スペース
-        directory_user_name = directory_user_name.strip(" ")
-        #全角スペース
-        directory_user_name = directory_user_name.strip("　")
+        directory_user_name = rename_for_windows(directory_user_name)
         saving_direcory_path = main_saving_direcory_path + directory_user_name + ("(") +str(user_id) + (")") + "/"
 
         #フォルダ名アップデート

--- a/pixiv_downloader_tqdm.py
+++ b/pixiv_downloader_tqdm.py
@@ -152,7 +152,7 @@ for user_id in tqdm(client_info["ids"], desc='users', leave=False):
         
         
         #こことってこれないとぐるぐる回る
-        user_illusts = aapi.user_illusts(user_id)
+        user_illusts = aapi.user_illusts(user_id, type="")
         #こちらでもいいが、めんどくさいのでwhile Trueで無限に回す
         for i in tqdm(range(total_works//30), desc='pages', leave=False):
         #while True:
@@ -218,7 +218,7 @@ for user_id in tqdm(client_info["ids"], desc='users', leave=False):
 
 
 
-                    if illust.type == "illust":
+                    if illust.type == "illust" or illust.type == "manga":
                         if illust.page_count == 1:
                             aapi.download(illust.meta_single_page.original_image_url, saving_direcory_path)
                         else:


### PR DESCRIPTION
変更点は以下です。

# 重要な修正
## 【重要】type = "manga"の作品が一切ダウンロードできていなかったので修正

`aapi.user_illusts(user_id, type="illust")`がデフォルトになっていたため、mangaがダウンロードできていなかった。
`type=""`とすることでillust、mangaともに取得できるようになったので修正。

# 細かな修正

* リネーム方法を関数を使用して新しく
* 初期設定でR-18Gも除外タグに追加
* aapi.parse_qs()のスリープを削除

