### PR TITLE
うごイラのダウンロードや命名など変更

### DIFF
--- a/pixiv_downloader.py
+++ b/pixiv_downloader.py
@@ -72,7 +72,7 @@ main_saving_direcory_path = "./img/"
 ugoira_gif  = True
 #画質良、ファイルサイズ小、ループしない（再生ソフト次第）、保存場所は直下
 ugoira_mp4  = True
-#画質最高（劣化なし）、ループ、ファイルサイズ大、移動可、保存場所はugoiraフォルダ内、delayが正確
+#画質最高（劣化なし）、ループ、ファイルサイズ大、移動可、保存場所は直下、delayが正確
 html_onefile = True
 
 #Filter by tag　e.g. target_tag = ["Fate/GrandOrder","FGO","FateGO","Fate/staynight"]

--- a/pixiv_downloader.py
+++ b/pixiv_downloader.py
@@ -235,6 +235,8 @@ for user_id in client_info["ids"]:
                         #うごイラに使われているすべての画像のダウンロード(オリジナル) 
                         #高画質低速
                         for frame in range(ugoira_frames):
+                            if os.path.exists(f'{dir_name}/{illust_id}_ugoira{frame}{ugoira_url[1]}'):
+                                continue
                             frame_url = ugoira_url[0] + str(frame) + ugoira_url[1]
                             aapi.download(frame_url, path=dir_name)
                             sleep(1)

--- a/pixiv_downloader.py
+++ b/pixiv_downloader.py
@@ -342,7 +342,7 @@ for user_id in client_info["ids"]:
                             </body>
                             </html>
                             """.format(width=width, height=height, frames=ugoira_frames, illust_id=illust_id, illust_b64=str(illust_b64))
-                            with open(f'{dir_name}/ugoira_onefile.html', 'w', encoding='utf-8') as f:
+                            with open(f'{saving_direcory_path}/{illust_id}.html', 'w', encoding='utf-8') as f:
                                 f.write(html)
 
                             

--- a/pixiv_downloader.py
+++ b/pixiv_downloader.py
@@ -176,14 +176,16 @@ for user_id in client_info["ids"]:
                     #https://www.pixiv.help/hc/ja/articles/235584428-pixiv%E3%81%AB%E6%8A%95%E7%A8%BF%E3%81%A7%E3%81%8D%E3%82%8B%E7%94%BB%E5%83%8F%E3%81%AE%E7%A8%AE%E9%A1%9E%E3%82%92%E7%9F%A5%E3%82%8A%E3%81%9F%E3%81%84   
                     file_name_head = saving_direcory_path + str(illust.id)+"_p" + str(illust.page_count-1) 
 
-                    if os.path.exists(file_name_head+".png") or os.path.exists(file_name_head+".jpg") or os.path.exists(file_name_head+".jpeg") or os.path.exists(file_name_head+".gif") or os.path.exists(saving_direcory_path+str(illust.id)+'_ugoira'):
+                    if os.path.exists(file_name_head+".png") or os.path.exists(file_name_head+".jpg") or os.path.exists(file_name_head+".jpeg") or os.path.exists(file_name_head+".gif"):
                         print("--------------------------------")
                         print("Title:"+str(illust.title)+" has already downloaded.")
                         continue
                     
-                    
-
-
+                    file_name_head = saving_direcory_path + str(illust.id)
+                    if (ugoira_gif==False or os.path.exists(file_name_head+".gif")) and (ugoira_mp4==False or os.path.exists(file_name_head+".mp4")) and (html_onefile==False or os.path.exists(file_name_head+".html")):
+                        print("--------------------------------")
+                        print("Title:"+str(illust.title)+" has already downloaded.")
+                        continue
 
                     
 

--- a/pixiv_downloader_tqdm.py
+++ b/pixiv_downloader_tqdm.py
@@ -257,6 +257,8 @@ for user_id in tqdm(client_info["ids"], desc='users', leave=False):
                         #うごイラに使われているすべての画像のダウンロード(オリジナル) 
                         #高画質低速
                         for frame in tqdm(range(ugoira_frames), desc='ugoiras download', leave=False):
+                            if os.path.exists(f'{dir_name}/{illust_id}_ugoira{frame}{ugoira_url[1]}'):
+                                continue
                             frame_url = ugoira_url[0] + str(frame) + ugoira_url[1]
                             aapi.download(frame_url, path=dir_name)
                             sleep(1)

--- a/pixiv_downloader_tqdm.py
+++ b/pixiv_downloader_tqdm.py
@@ -360,7 +360,7 @@ for user_id in tqdm(client_info["ids"], desc='users', leave=False):
                             </body>
                             </html>
                             """.format(width=width, height=height, frames=ugoira_frames, illust_id=illust_id, illust_b64=str(illust_b64))
-                            with open(f'{dir_name}/ugoira_onefile.html', 'w', encoding='utf-8') as f:
+                            with open(f'{saving_direcory_path}/{illust_id}.html', 'w', encoding='utf-8') as f:
                                 f.write(html)
 
                             

--- a/pixiv_downloader_tqdm.py
+++ b/pixiv_downloader_tqdm.py
@@ -188,7 +188,7 @@ for user_id in tqdm(client_info["ids"], desc='users', leave=False):
                     #https://www.pixiv.help/hc/ja/articles/235584428-pixiv%E3%81%AB%E6%8A%95%E7%A8%BF%E3%81%A7%E3%81%8D%E3%82%8B%E7%94%BB%E5%83%8F%E3%81%AE%E7%A8%AE%E9%A1%9E%E3%82%92%E7%9F%A5%E3%82%8A%E3%81%9F%E3%81%84   
                     file_name_head = saving_direcory_path + str(illust.id)+"_p" + str(illust.page_count-1) 
 
-                    if os.path.exists(file_name_head+".png") or os.path.exists(file_name_head+".jpg") or os.path.exists(file_name_head+".jpeg") or os.path.exists(file_name_head+".gif") or os.path.exists(saving_direcory_path+str(illust.id)+'_ugoira'):
+                    if os.path.exists(file_name_head+".png") or os.path.exists(file_name_head+".jpg") or os.path.exists(file_name_head+".jpeg") or os.path.exists(file_name_head+".gif"):
                         tqdm.write("--------------------------------")
                         tqdm.write("Title:"+str(illust.title)+" has already downloaded.")
                         #print("--------------------------------")
@@ -197,7 +197,13 @@ for user_id in tqdm(client_info["ids"], desc='users', leave=False):
                     
                     
 
-
+                    file_name_head = saving_direcory_path + str(illust.id)
+                    if (ugoira_gif==False or os.path.exists(file_name_head+".gif")) and (ugoira_mp4==False or os.path.exists(file_name_head+".mp4")) and (html_onefile==False or os.path.exists(file_name_head+".html")):
+                        tqdm.write("--------------------------------")
+                        tqdm.write("Title:"+str(illust.title)+" has already downloaded.")
+                        #print("--------------------------------")
+                        #print("Title:"+str(illust.title)+" has already downloaded.")
+                        continue
 
                     
 

--- a/pixiv_downloader_tqdm.py
+++ b/pixiv_downloader_tqdm.py
@@ -76,7 +76,7 @@ main_saving_direcory_path = "./img/"
 ugoira_gif  = True
 #画質良、ファイルサイズ小、ループしない（再生ソフト次第）、保存場所は直下
 ugoira_mp4  = True
-#画質最高（劣化なし）、ループ、ファイルサイズ大、移動可、保存場所はugoiraフォルダ内、delayが正確
+#画質最高（劣化なし）、ループ、ファイルサイズ大、移動可、保存場所は直下、delayが正確
 html_onefile = True
 
 #Filter by tag　e.g. target_tag = ["Fate/GrandOrder","FGO","FateGO","Fate/staynight"]


### PR DESCRIPTION
重要なものとしては、htmlの名前の変更と保存場所の変更

あとはダウンロードを最適化したりした。

[htmlのugoiraの名前、保温場所を変更](https://github.com/yuki-2000/pixiv_downloader/commit/e58129e7ffd23ecafbf5d51cdb374a12a2a6a66d)

[うごイラダウンロード済みかの可否の変更](https://github.com/yuki-2000/pixiv_downloader/commit/3e31c9a9105848c654a104ba92039da2e69c3d7a)

[ダウンロードされていないうごイラの元画像のみダウンロードするように変更](https://github.com/yuki-2000/pixiv_downloader/commit/66fb61ee6013924505b41f30bc7b95c330bf7b84)

[うごイラhtml保存場所の説明変更](https://github.com/yuki-2000/pixiv_downloader/commit/c6f3ead21cee744919ec1e5cde338bce06c53063)